### PR TITLE
Add desktop UI with PyQt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # GMAO
-Crréation d'un logiciel de GMAO
+
+Prototype simple de Gestion de la Maintenance Assistée par Ordinateur.
+
+Ce projet propose une petite application de bureau écrite avec PyQt5 et SQLite. Une interface web Flask est également fournie à titre d'exemple.
+
+Fonctionnalités principales :
+
+- gérer une liste d'équipements ;
+- enregistrer des tâches de maintenance associées à chaque équipement ;
+- suivre l'état des tâches (en attente ou réalisées).
+
+## Prérequis
+
+- Python 3.8 ou supérieur
+- `pip` pour installer les dépendances
+
+## Installation
+
+1. Installez les dépendances :
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Lancez l'application de bureau :
+   ```bash
+   python desktop.py
+   ```
+   (l'interface web peut toujours être lancée avec `python app.py` si besoin)
+
+Les données sont stockées dans un fichier `gmao.db` (SQLite) créé automatiquement au premier lancement.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,56 @@
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///gmao.db'
+db = SQLAlchemy(app)
+
+class Equipment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+    description = db.Column(db.String(200))
+
+class Task(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    equipment_id = db.Column(db.Integer, db.ForeignKey('equipment.id'), nullable=False)
+    description = db.Column(db.String(200), nullable=False)
+    date_created = db.Column(db.DateTime, default=datetime.utcnow)
+    status = db.Column(db.String(20), default='pending')
+
+    equipment = db.relationship('Equipment', backref=db.backref('tasks', lazy=True))
+
+@app.route('/')
+def index():
+    tasks = Task.query.all()
+    equipments = Equipment.query.all()
+    return render_template('index.html', tasks=tasks, equipments=equipments)
+
+@app.route('/add_equipment', methods=['POST'])
+def add_equipment():
+    name = request.form['name']
+    description = request.form.get('description')
+    eq = Equipment(name=name, description=description)
+    db.session.add(eq)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/add_task', methods=['POST'])
+def add_task():
+    equipment_id = request.form['equipment_id']
+    description = request.form['description']
+    task = Task(equipment_id=equipment_id, description=description)
+    db.session.add(task)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/update_task/<int:task_id>', methods=['POST'])
+def update_task(task_id):
+    task = Task.query.get_or_404(task_id)
+    task.status = request.form['status']
+    db.session.commit()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    db.create_all()
+    app.run(debug=False)

--- a/desktop.py
+++ b/desktop.py
@@ -1,0 +1,127 @@
+import sys
+import sqlite3
+from PyQt5.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QHBoxLayout,
+    QLabel, QLineEdit, QPushButton, QListWidget, QListWidgetItem
+)
+
+DB_FILE = 'gmao.db'
+
+conn = sqlite3.connect(DB_FILE)
+cur = conn.cursor()
+cur.execute("""CREATE TABLE IF NOT EXISTS equipment (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT
+)""")
+cur.execute("""CREATE TABLE IF NOT EXISTS task (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    equipment_id INTEGER,
+    description TEXT NOT NULL,
+    date_created TEXT,
+    status TEXT DEFAULT 'pending',
+    FOREIGN KEY(equipment_id) REFERENCES equipment(id)
+)""")
+conn.commit()
+
+class MainWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("GMAO")
+        self.resize(600, 400)
+        layout = QHBoxLayout()
+        self.setLayout(layout)
+
+        # Equipment list and add form
+        eq_layout = QVBoxLayout()
+        eq_layout.addWidget(QLabel("Équipements"))
+        self.eq_list = QListWidget()
+        self.eq_list.currentItemChanged.connect(self.load_tasks)
+        eq_layout.addWidget(self.eq_list)
+        self.eq_name = QLineEdit()
+        self.eq_name.setPlaceholderText("Nom")
+        self.eq_desc = QLineEdit()
+        self.eq_desc.setPlaceholderText("Description")
+        add_eq_btn = QPushButton("Ajouter équipement")
+        add_eq_btn.clicked.connect(self.add_equipment)
+        eq_layout.addWidget(self.eq_name)
+        eq_layout.addWidget(self.eq_desc)
+        eq_layout.addWidget(add_eq_btn)
+        layout.addLayout(eq_layout)
+
+        # Task list and add form
+        task_layout = QVBoxLayout()
+        task_layout.addWidget(QLabel("Tâches"))
+        self.task_list = QListWidget()
+        task_layout.addWidget(self.task_list)
+        self.task_desc = QLineEdit()
+        self.task_desc.setPlaceholderText("Nouvelle tâche")
+        add_task_btn = QPushButton("Ajouter tâche")
+        add_task_btn.clicked.connect(self.add_task)
+        done_btn = QPushButton("Marquer comme réalisée")
+        done_btn.clicked.connect(self.mark_done)
+        task_layout.addWidget(self.task_desc)
+        task_layout.addWidget(add_task_btn)
+        task_layout.addWidget(done_btn)
+        layout.addLayout(task_layout)
+
+        self.load_equipment()
+
+    def load_equipment(self):
+        self.eq_list.clear()
+        for row in cur.execute("SELECT id, name FROM equipment"):
+            item = QListWidgetItem(row[1])
+            item.setData(0, row[0])
+            self.eq_list.addItem(item)
+        if self.eq_list.count():
+            self.eq_list.setCurrentRow(0)
+
+    def load_tasks(self):
+        self.task_list.clear()
+        item = self.eq_list.currentItem()
+        if not item:
+            return
+        eq_id = item.data(0)
+        for row in cur.execute("SELECT id, description, status FROM task WHERE equipment_id=?", (eq_id,)):
+            t_item = QListWidgetItem(f"{row[1]} - {row[2]}")
+            t_item.setData(0, row[0])
+            self.task_list.addItem(t_item)
+
+    def add_equipment(self):
+        name = self.eq_name.text().strip()
+        desc = self.eq_desc.text().strip()
+        if not name:
+            return
+        cur.execute("INSERT INTO equipment(name, description) VALUES (?, ?)", (name, desc))
+        conn.commit()
+        self.eq_name.clear(); self.eq_desc.clear()
+        self.load_equipment()
+
+    def add_task(self):
+        item = self.eq_list.currentItem()
+        desc = self.task_desc.text().strip()
+        if not item or not desc:
+            return
+        eq_id = item.data(0)
+        cur.execute(
+            "INSERT INTO task(equipment_id, description, date_created) VALUES (?, ?, datetime('now'))",
+            (eq_id, desc)
+        )
+        conn.commit()
+        self.task_desc.clear()
+        self.load_tasks()
+
+    def mark_done(self):
+        item = self.task_list.currentItem()
+        if not item:
+            return
+        task_id = item.data(0)
+        cur.execute("UPDATE task SET status='done' WHERE id=?", (task_id,))
+        conn.commit()
+        self.load_tasks()
+
+app = QApplication(sys.argv)
+window = MainWindow()
+window.show()
+app.exec_()
+conn.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask==2.2.5
+flask_sqlalchemy==3.0.3
+PyQt5==5.15.10

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Simple GMAO</title>
+</head>
+<body>
+  <h1>Équipements</h1>
+  <ul>
+    {% for eq in equipments %}
+    <li>{{ eq.name }} - {{ eq.description or '' }}</li>
+    {% endfor %}
+  </ul>
+  <h2>Ajouter un équipement</h2>
+  <form method="post" action="{{ url_for('add_equipment') }}">
+    <input name="name" placeholder="Nom" required>
+    <input name="description" placeholder="Description">
+    <button type="submit">Ajouter</button>
+  </form>
+
+  <h1>Tâches de maintenance</h1>
+  <ul>
+    {% for t in tasks %}
+    <li>
+      {{ t.description }} ({{ t.equipment.name }}) - {{ t.status }}
+      <form method="post" action="{{ url_for('update_task', task_id=t.id) }}">
+        <select name="status">
+          <option value="pending" {% if t.status == 'pending' %}selected{% endif %}>En attente</option>
+          <option value="done" {% if t.status == 'done' %}selected{% endif %}>Réalisé</option>
+        </select>
+        <button type="submit">Mettre à jour</button>
+      </form>
+    </li>
+    {% endfor %}
+  </ul>
+  <h2>Ajouter une tâche</h2>
+  <form method="post" action="{{ url_for('add_task') }}">
+    <select name="equipment_id" required>
+      {% for eq in equipments %}
+      <option value="{{ eq.id }}">{{ eq.name }}</option>
+      {% endfor %}
+    </select>
+    <input name="description" placeholder="Description" required>
+    <button type="submit">Ajouter</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a PyQt5 desktop application to manage equipment and tasks
- update README for desktop instructions
- disable Flask debug mode
- include PyQt5 in requirements

## Testing
- `python -m py_compile app.py desktop.py`


------
https://chatgpt.com/codex/tasks/task_e_6862bc91ae448322a872339f36f3f707